### PR TITLE
Add Foxdriver as remote-debug client

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ There are a variety of tools which target some or all of the above implementatio
 - [VS Code debuggers](https://github.com/Microsoft/vscode-chrome-debug-core/blob/master/README.md)
 - [RemoteDebug integrations](https://remotedebug.org/integrations/)
 - [sonarwhal](https://sonarwhal.com/)
+- [Foxdriver](https://github.com/saucelabs/foxdriver)
 
 ## Key Use Cases
 


### PR DESCRIPTION
We @saucelabs build Foxdriver to access the remote-debug protocol of Firefox. It is definitely not complete or up to date but I thought worth adding.